### PR TITLE
Add ::jtag_vpi:0-r5

### DIFF
--- a/jtag_vpi/jtag_vpi-r5.core
+++ b/jtag_vpi/jtag_vpi-r5.core
@@ -1,0 +1,44 @@
+CAPI=2:
+
+name : ::jtag_vpi:0-r5
+description : TCP/IP controlled VPI JTAG Interface
+
+filesets :
+  common :
+    files : [jtag_common.c, jtag_common.h : {is_include_file : true}]
+    file_type : cSource
+
+  vpi :
+    files :
+      - jtag_vpi.c : {file_type : cSource}
+      - jtag_vpi.v : {file_type : verilogSource}
+
+  verilator :
+    files :
+      - jtagServer.cpp
+      - jtagServer.h : {is_include_file : true}
+    file_type : cppSource
+
+vpi:
+  jtag_vpi: {filesets : [common, vpi]}
+
+targets :
+  default:
+    filesets :
+      - common
+      - "tool_verilator? (verilator)"
+      - "!tool_verilator? (vpi)"
+    parameters: [jtag_vpi_enable]
+    vpi : [jtag_vpi]
+
+parameters:
+  jtag_vpi_enable:
+    datatype    : bool
+    description : Enable JTAG debug interface
+    paramtype   : plusarg
+
+provider:
+  name    : github
+  user    : fjullien
+  repo    : jtag_vpi
+version : 600e65bb85d92d67a932c3b153991a2b74f78a77


### PR DESCRIPTION
Adding `jtag_vpi:0-r5` to the FuseSoC standard core library. This is a follow-up to https://github.com/fjullien/jtag_vpi/pull/7.

The inclusion of `jtag_vpi:0-r5` to the library can be done anytime as convenient (for example synchronized with SweRVolf version bumps). No need to rush this one.