### PR TITLE
Add open-source FPGA cores (OpenFPGA/SOFA)

### DIFF
--- a/openfpga/sofa-chd.core
+++ b/openfpga/sofa-chd.core
@@ -1,0 +1,20 @@
+CAPI=2:
+
+name: openfpga:cores:sofa-chd:1.0
+description: Hard-IP 12x12 FPGA core, Skywater Open-source FpgA (SOFA), custom high-density design
+
+filesets:
+  rtl:
+    files:
+      - FPGA1212_SOFA_CHD_PNR/fpga_top/fpga_top_icv_in_design.top_only.pt.v
+    file_type: verilogSource
+
+targets:
+  default:
+    filesets: [rtl]
+
+provider:
+  name    : github
+  user    : lnis-uofu
+  repo    : SOFA
+  version : 47b839fa0aafcef897674d4cf7c3a465f4a65e88

--- a/openfpga/sofa-hd.core
+++ b/openfpga/sofa-hd.core
@@ -1,0 +1,20 @@
+CAPI=2:
+
+name: openfpga:cores:sofa-hd:1.0
+description: Hard-IP 12x12 FPGA core, Skywater Open-source FpgA (SOFA), high-density design
+
+filesets:
+  rtl:
+    files:
+      - FPGA1212_SOFA_HD_PNR/fpga_top/fpga_top_icv_in_design.top_only.pt.v
+    file_type: verilogSource
+
+targets:
+  default:
+    filesets: [rtl]
+
+provider:
+  name    : github
+  user    : lnis-uofu
+  repo    : SOFA
+  version : 47b839fa0aafcef897674d4cf7c3a465f4a65e88

--- a/openfpga/sofa-qlhd.core
+++ b/openfpga/sofa-qlhd.core
@@ -1,0 +1,20 @@
+CAPI=2:
+
+name: openfpga:cores:sofa-qlhd:1.0
+description: Hard-IP 12x12 FPGA core, Skywater Open-source FpgA (SOFA), QuickLogic' soft-adder and high-density design
+
+filesets:
+  rtl:
+    files:
+      - FPGA1212_QLSOFA_HD_PNR/fpga_top/fpga_top_icv_in_design.top_only.pt.v
+    file_type: verilogSource
+
+targets:
+  default:
+    filesets: [rtl]
+
+provider:
+  name    : github
+  user    : lnis-uofu
+  repo    : SOFA
+  version : 47b839fa0aafcef897674d4cf7c3a465f4a65e88


### PR DESCRIPTION
Hello,

I am part of the LNIS research lab at the University of Utah ([Github](https://github.com/lnis-uofu), [Website](https://www.lnis-uofu.com/)), which has developed OpenFPGA - an automatic IP generator for customizable FPGA architectures ([Github](https://github.com/lnis-uofu/OpenFPGA)).
FuseSoC seems to be an excellent opportunity to integrate hard-IP FPGA cores as hardware accelerators. Also, we built 3 open-source FPGA cores using the Google Skywater PDK (SOFA), with all the features listed below.
Following the fusesoc-cores documentation, I have described each FPGA core as a FuseSoC's core that can be integrated into a future multi-IP systems.

Thanks for reviewing my application, and please let me know if anything is wrong!

- **SOFA_CHD: Skywater Open-source FpgA (SOFA) - Custom High-Density Design**
  - Open-source 12x12 FPGA with adapted QuickLogic' soft-adder CLB architecture ([documentation](https://skywater-openfpga.readthedocs.io/en/latest/datasheet/sofa_chd/), [github](https://github.com/lnis-uofu/SOFA))
  - Designed with Google Skywater 130nm PDK with HD standard cell library + Custom Transmission Gate Cells
  - Base K4 architecture from VPR with 60 vertical and horizontal channels
  - Fabricated with eFabless Open MPW-one shuttle program (slot-039)

- **SOFA_HD: Skywater Open-source FpgA (SOFA) - High-Density Design**
  - Open-source 12x12 FPGA ([documentation](https://skywater-openfpga.readthedocs.io/en/latest/datasheet/sofa_hd/), [github](https://github.com/lnis-uofu/SOFA))
  - Designed with Google Skywater 130nm PDK with HD standard cell library
  - Base K4 architecture from VPR with 40 vertical and horizontal channels
  - No adders (carry-chain) or flipflop reset pins
  - Fabricated with eFabless Open MPW-one shuttle program (slot-017)
 
- **SOFA_QLHD: Skywater Open-source FpgA (SOFA) - QuickLogic' soft-adder High-Density Design**
  - Opensource 12x12 FPGA with adapted QuickLogic' soft-adder CLB architecture ([documentation](https://skywater-openfpga.readthedocs.io/en/latest/datasheet/qlsofa_hd/), [github](https://github.com/lnis-uofu/SOFA))
  - Designed with Skywater130nm PDK with HD standard cell library
  - Base K4 architecture from VPR with 60 vertical and horizontal channels
  - Fabricated with eFabless Open MPW-one shuttle program (slot-036)

Cheers!