### PR TITLE
Add cmod_a7_35t to servant.

### DIFF
--- a/serv/servant-1.0.2-r1.core
+++ b/serv/servant-1.0.2-r1.core
@@ -63,6 +63,11 @@ filesets:
       - servant/servix_clock_gen.v : {file_type : verilogSource}
       - servant/servix.v : {file_type : verilogSource}
       - data/arty_a7_35t.xdc : {file_type : xdc}
+  cmod_a7_35t:
+    files:
+      - servant/servix_clock_gen.v : {file_type : verilogSource}
+      - servant/servix.v : {file_type : verilogSource}
+      - data/cmod_a7_35t.xdc : {file_type : xdc}
 
   pipistrello:
     files:
@@ -173,6 +178,14 @@ targets:
     parameters : [memfile, memsize, frequency=16]
     tools:
       vivado: {part : xc7a35ticsg324-1L}
+    toplevel : servix
+
+  cmod_a7_35t:
+    default_tool: vivado
+    filesets : [mem_files, soc, cmod_a7_35t]
+    parameters : [memfile, memsize, frequency=16]
+    tools:
+      vivado: {part : xc7a35tcpg236-1}
     toplevel : servix
 
   pipistrello:

--- a/serv/servant-1.0.2.core
+++ b/serv/servant-1.0.2.core
@@ -63,6 +63,11 @@ filesets:
       - servant/servix_clock_gen.v : {file_type : verilogSource}
       - servant/servix.v : {file_type : verilogSource}
       - data/arty_a7_35t.xdc : {file_type : xdc}
+  cmod_a7_35t:
+    files:
+      - servant/servix_clock_gen.v : {file_type : verilogSource}
+      - servant/servix.v : {file_type : verilogSource}
+      - data/cmod_a7_35t.xdc : {file_type : xdc}
 
   pipistrello:
     files:
@@ -173,6 +178,14 @@ targets:
     parameters : [memfile, memsize, frequency=16]
     tools:
       vivado: {part : xc7a35ticsg324-1L}
+    toplevel : servix
+
+  cmod_a7_35t:
+    default_tool: vivado
+    filesets : [mem_files, soc, cmod_a7_35t]
+    parameters : [memfile, memsize, frequency=16]
+    tools:
+      vivado: {part : xc7a35tcpg236-1}
     toplevel : servix
 
   pipistrello:


### PR DESCRIPTION
Is this useful at all?
Or should this be added to all cores where applicable?
Is this needed for corescore? I was not sure, so I just added it...