### PR TITLE
Add pulp-platform.org::axi2apb:0.1.1-r3

### DIFF
--- a/pulp-platform.org/axi2apb-0.1.1-r3.core
+++ b/pulp-platform.org/axi2apb-0.1.1-r3.core
@@ -1,0 +1,22 @@
+CAPI=2:
+name: pulp-platform.org::axi2apb:0.1.1-r3
+
+filesets:
+  rtl:
+    files:
+      - src/axi2apb.sv
+      - src/axi2apb_64_32.sv
+      - src/axi2apb_wrap.sv
+    file_type : systemVerilogSource
+    depend:
+      - ">=pulp-platform.org::apb:0.1.0"
+      - ">=pulp-platform.org::axi:0.4.5"
+      - pulp-platform.org::axi_slice
+
+targets : {default : {filesets : [rtl]}}
+
+provider:
+  name    : github
+  user    : pulp-platform
+  repo    : axi2apb
+  version : be292ade4f3c027a065e63e85bd7c1927b4a676f


### PR DESCRIPTION
Removed invalid property that was present in the previous versions.