### PR TITLE
Shorne cores 20240824

### DIFF
--- a/mor1kx/mor1kx-5.2.core
+++ b/mor1kx/mor1kx-5.2.core
@@ -1,0 +1,206 @@
+CAPI=2:
+
+name : ::mor1kx:5.2
+description : mor1kx - an OpenRISC processor IP core
+
+filesets:
+  core:
+    files:
+      - rtl/verilog/mor1kx-defines.v : {is_include_file : true}
+      - rtl/verilog/mor1kx-sprs.v : {is_include_file : true}
+      - rtl/verilog/mor1kx_utils.vh : {is_include_file : true}
+      - rtl/verilog/mor1kx_branch_predictor_gshare.v
+      - rtl/verilog/mor1kx_branch_predictor_simple.v
+      - rtl/verilog/mor1kx_branch_predictor_saturation_counter.v
+      - rtl/verilog/mor1kx_branch_prediction.v
+      - rtl/verilog/mor1kx_bus_if_wb32.v
+      - rtl/verilog/mor1kx_cache_lru.v
+      - rtl/verilog/mor1kx_cfgrs.v
+      - rtl/verilog/mor1kx_cpu_cappuccino.v
+      - rtl/verilog/mor1kx_cpu_espresso.v
+      - rtl/verilog/mor1kx_cpu_prontoespresso.v
+      - rtl/verilog/mor1kx_cpu.v
+      - rtl/verilog/mor1kx_ctrl_cappuccino.v
+      - rtl/verilog/mor1kx_ctrl_espresso.v
+      - rtl/verilog/mor1kx_ctrl_prontoespresso.v
+      - rtl/verilog/mor1kx_dcache.v
+      - rtl/verilog/mor1kx_decode_execute_cappuccino.v
+      - rtl/verilog/mor1kx_decode.v
+      - rtl/verilog/mor1kx_dmmu.v
+      - rtl/verilog/mor1kx_execute_alu.v
+      - rtl/verilog/mor1kx_execute_ctrl_cappuccino.v
+      - rtl/verilog/mor1kx_fetch_cappuccino.v
+      - rtl/verilog/mor1kx_fetch_espresso.v
+      - rtl/verilog/mor1kx_fetch_prontoespresso.v
+      - rtl/verilog/mor1kx_fetch_tcm_prontoespresso.v
+      - rtl/verilog/mor1kx_icache.v
+      - rtl/verilog/mor1kx_immu.v
+      - rtl/verilog/mor1kx_lsu_cappuccino.v
+      - rtl/verilog/mor1kx_lsu_espresso.v
+      - rtl/verilog/mor1kx_pcu.v
+      - rtl/verilog/mor1kx_pic.v
+      - rtl/verilog/mor1kx_rf_cappuccino.v
+      - rtl/verilog/mor1kx_rf_espresso.v
+      - rtl/verilog/mor1kx_simple_dpram_sclk.v
+      - rtl/verilog/mor1kx_store_buffer.v
+      - rtl/verilog/mor1kx_ticktimer.v
+      - rtl/verilog/mor1kx_true_dpram_sclk.v
+      - rtl/verilog/mor1kx.v
+      - rtl/verilog/mor1kx_wb_mux_cappuccino.v
+      - rtl/verilog/mor1kx_wb_mux_espresso.v
+    file_type : verilogSource
+
+  fpu:
+    files:
+      - rtl/verilog/pfpu32/pfpu32_addsub.v
+      - rtl/verilog/pfpu32/pfpu32_cmp.v
+      - rtl/verilog/pfpu32/pfpu32_f2i.v
+      - rtl/verilog/pfpu32/pfpu32_i2f.v
+      - rtl/verilog/pfpu32/pfpu32_muldiv.v
+      - rtl/verilog/pfpu32/pfpu32_rnd.v
+      - rtl/verilog/pfpu32/pfpu32_top.v
+    file_type : verilogSource
+
+  monitor:
+    files : [bench/verilog/mor1kx_monitor.v]
+    file_type : verilogSource
+
+parameters:
+  trace_enable:
+    datatype    : bool
+    description : Enable mor1kx instruction trace
+    paramtype   : plusarg
+
+  trace_to_screen:
+    datatype    : bool
+    description : Output mor1kx instruction trace to screen
+    paramtype   : plusarg
+
+  FEATURE_DATACACHE:
+    datatype   : str
+    description: Enable the mor1kx data cache, use ENABLED, NONE. default NONE
+    paramtype  : vlogparam
+    scope      : private
+
+  FEATURE_DMMU:
+    datatype   : str
+    description: Enable the mor1kx data bus mmu, use ENABLED, NONE. default NONE
+    paramtype  : vlogparam
+    scope      : private
+
+  FEATURE_INSTRUCTIONCACHE:
+    datatype   : str
+    description: Enable the mor1kx instruction cache, use ENABLED, NONE. default NONE
+    paramtype  : vlogparam
+    scope      : private
+
+  FEATURE_IMMU:
+    datatype   : str
+    description: Enable the mor1kx instruction bus mmu, use ENABLED, NONE. default NONE
+    paramtype  : vlogparam
+    scope      : private
+
+  FEATURE_FPU:
+    datatype   : str
+    description: Enable the mor1kx floating point unit, use ENABLED, NONE. default NONE
+    paramtype  : vlogparam
+    scope      : private
+
+  FEATURE_ROR:
+    datatype   : str
+    description: Enable the mor1kx rotate right instruction, use ENABLED, NONE. default NONE
+    paramtype  : vlogparam
+    scope      : private
+
+  FEATURE_EXT:
+    datatype   : str
+    description: Enable the mor1kx sign extend instructions, use ENABLED, NONE. default NONE
+    paramtype  : vlogparam
+    scope      : private
+
+  OPTION_DCACHE_BLOCK_WIDTH:
+    datatype   : int
+    description: Configure mor1kx d-cache block width in bits, controls block size. default 5
+    paramtype  : vlogparam
+    scope      : private
+
+  OPTION_DCACHE_LIMIT_WIDTH:
+    datatype   : int
+    description: Configure mor1kx d-cache limit in bits. default 32
+    paramtype  : vlogparam
+    scope      : private
+
+  OPTION_DCACHE_SET_WIDTH:
+    datatype   : int
+    description: Configure mor1kx d-cache set width in bits, controls numbers of sets. default 9
+    paramtype  : vlogparam
+    scope      : private
+
+  OPTION_DCACHE_WAYS:
+    datatype   : int
+    description: Configure mor1kx d-cache ways, controls number of blocks per set. default 2
+    paramtype  : vlogparam
+    scope      : private
+
+  OPTION_ICACHE_BLOCK_WIDTH:
+    datatype   : int
+    description: Configure mor1kx i-cache block width in bits, controls block size. default 5
+    paramtype  : vlogparam
+    scope      : private
+
+  OPTION_ICACHE_LIMIT_WIDTH:
+    datatype   : int
+    description: Configure mor1kx i-cache limit in bits. default 32
+    paramtype  : vlogparam
+    scope      : private
+
+  OPTION_ICACHE_SET_WIDTH:
+    datatype   : int
+    description: Configure mor1kx i-cache set width in bits, controls numbers of sets. default 9
+    paramtype  : vlogparam
+    scope      : private
+
+  OPTION_ICACHE_WAYS:
+    datatype   : int
+    description: Configure mor1kx i-cache ways, controls number of blocks per set. default 2
+    paramtype  : vlogparam
+    scope      : private
+
+  OPTION_RF_NUM_SHADOW_GPR:
+    datatype   : int
+    description: Configure mor1kx available shadow registers. default 0
+    paramtype  : vlogparam
+    scope      : private
+
+targets:
+  default:
+    filesets:
+      - core
+      - fpu
+      - "tool_icarus? (monitor)"
+      - "tool_isim? (monitor)"
+      - "tool_modelsim? (monitor)"
+      - "tool_rivierapro? (monitor)"
+      - "tool_xsim? (monitor)"
+    parameters: [trace_enable, trace_to_screen]
+
+  synth:
+    default_tool : icestorm
+    filesets : [core , fpu]
+    tools:
+      icestorm:
+        arch: xilinx
+        pnr: none
+    toplevel : mor1kx
+    parameters: [FEATURE_DATACACHE, FEATURE_DMMU,
+                 FEATURE_INSTRUCTIONCACHE, FEATURE_IMMU,
+                 FEATURE_FPU, FEATURE_ROR, FEATURE_EXT,
+                 OPTION_DCACHE_BLOCK_WIDTH, OPTION_DCACHE_LIMIT_WIDTH, OPTION_DCACHE_SET_WIDTH, OPTION_DCACHE_WAYS,
+                 OPTION_ICACHE_BLOCK_WIDTH, OPTION_ICACHE_LIMIT_WIDTH, OPTION_ICACHE_SET_WIDTH, OPTION_ICACHE_WAYS,
+                 OPTION_RF_NUM_SHADOW_GPR]
+
+provider:
+  name    : github
+  user    : openrisc
+  repo    : mor1kx
+  version : v5.2

--- a/or1ksim_trace/or1ksim_trace-1.0.core
+++ b/or1ksim_trace/or1ksim_trace-1.0.core
@@ -1,0 +1,33 @@
+CAPI=2:
+
+name: ::or1ksim_trace:1.0
+description: "OpenRISC instruction trace routines from or1ksim"
+
+filesets:
+  verilator_tb:
+    files:
+      - cpu/or32/or32.c
+      - cpu/or1k/opcode/or32.h: {is_include_file: true}
+      - or1ksim_trace.c
+      - or1ksim_trace.h:        {is_include_file: true}
+    file_type: cSource
+
+targets:
+  default:
+    filesets: [verilator_tb]
+    parameters: [trace_enable]
+    tools:
+      verilator:
+        verilator_options: ["-CFLAGS -DOR1KSIM_TRACE_STANDALONE"]
+
+parameters:
+  trace_enable:
+    datatype: bool
+    description: Enable OpenRISC instruction tracing
+    paramtype: cmdlinearg
+
+provider:
+  name: github
+  user: openrisc
+  repo: or1ksim
+  version: trace-1.0

--- a/verilator_tb_utils/verilator_tb_utils-1.1.core
+++ b/verilator_tb_utils/verilator_tb_utils-1.1.core
@@ -1,0 +1,61 @@
+CAPI=2:
+
+name: ::verilator_tb_utils:1.1
+description: "Verilator test bench utility class"
+
+filesets:
+  verilator_tb:
+    files:
+      - verilator_tb_utils.cpp
+      - verilator_tb_utils.h:   {is_include_file: true}
+      - jtagServer.cpp
+      - jtagServer.h:           {is_include_file: true}
+    file_type: cppSource
+    depend: [elf-loader]
+
+targets:
+  default:
+    filesets: [verilator_tb]
+    parameters: [timeout, elf_load, bin_load, jtag_server, vcd, vcdstart, vcdstop]
+
+parameters:
+  timeout:
+    datatype: int
+    description: Stop the simulator after VAL cycles
+    paramtype: cmdlinearg
+
+  elf_load:
+    datatype: file
+    description: ELF file to preload to memory
+    paramtype: cmdlinearg
+
+  bin_load:
+    datatype: file
+    description: Binary file to preload to memory (created from elf with objcopy)
+    paramtype: cmdlinearg
+
+  jtag_server:
+    datatype: int
+    description: Enable openocd JTAG server and define the TCP PORT to listen on
+    paramtype: cmdlinearg
+
+  vcd:
+    datatype: file
+    description: Enable and save VCD to FILE
+    paramtype: cmdlinearg
+
+  vcdstart:
+    datatype: int
+    description: Delay VCD generation until after VAL cycles
+    paramtype: cmdlinearg
+
+  vcdstop:
+    datatype: int
+    description: Terminate VCD generation at VAL cycles
+    paramtype: cmdlinearg
+
+provider:
+  name : github
+  user : stffrdhrn
+  repo : verilator_tb_utils
+  version : v1.1


### PR DESCRIPTION
These are a few cores I have created recently to get openrisc instruction traces working with Verilator.  These are used in [mor1kx-generic](https://github.com/stffrdhrn/mor1kx-generic) with:

```
fusesoc run --target mor1kx_tb --tool varilator mor1kx-generic \
  --elf_load ./openrisc-asm --trace_enable
```

Note, with icarus backend there is a monitor Verilog module that does this using Verilog system tasks/functions.